### PR TITLE
chore: add Copilot setup steps for coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,66 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - Makefile
+      - pyproject.toml
+      - uv.lock
+      - apps/artagent/frontend/package.json
+      - apps/artagent/frontend/package-lock.json
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - Makefile
+      - pyproject.toml
+      - uv.lock
+      - apps/artagent/frontend/package.json
+      - apps/artagent/frontend/package-lock.json
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 59
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/artagent/frontend/package-lock.json
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Cache uv artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix apps/artagent/frontend --ignore-scripts
+
+      - name: Environment smoke check
+        run: make ci-fast

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,19 @@ eval:
 check_and_fix_code_quality: fix_code_quality check_code_quality
 check_and_fix_test_quality: run_unit_tests
 
+# Fast deterministic validation used by GitHub Copilot coding-agent setup
+ci-fast:
+	@echo "⚡ Running ci-fast validation"
+	@echo "- Python bytecode compile check"
+	@for d in apps/artagent/backend src tests/evaluation utils; do \
+		echo "  • $$d"; \
+		$(UV_BIN) run python -m compileall -q "$$d"; \
+	done
+	@echo "- Dependency import smoke check"
+	$(UV_BIN) run python -c "import fastapi, yaml, pydantic, aiohttp; print('imports: ok')"
+	@echo "- Scenario orchestration YAML parse check"
+	$(UV_BIN) run python -c "from pathlib import Path; import yaml; files=list(Path('apps/artagent/backend/registries/scenariostore').rglob('orchestration.yaml')); [yaml.safe_load(p.read_text(encoding='utf-8')) for p in files]; print(f'orchestration yamls: {len(files)} parsed')"
+
 
 # ANSI color codes for pretty output
 RED = \033[0;31m

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@
 # Each target is documented for clarity and maintainability
 ############################################################
 
-# Ensure uv is in PATH (installed via curl -LsSf https://astral.sh/uv/install.sh | sh)
+# Resolve uv from PATH first (works in GitHub Actions via setup-uv),
+# then fall back to the default local install location.
+UV_BIN ?= $(shell command -v uv 2>/dev/null)
+ifeq ($(strip $(UV_BIN)),)
 UV_BIN := $(HOME)/.local/bin/uv
+endif
 export PATH := $(HOME)/.local/bin:$(PATH)
 
 # Python interpreter to use (via uv)


### PR DESCRIPTION
## Summary
- add  for deterministic GitHub Copilot coding-agent environment setup
- install Python/Node toolchains and dependencies with caching
- add ⚡ Running ci-fast validation
- Python bytecode compile check
  • apps/artagent/backend
  • src
  • tests/evaluation
  • utils
- Dependency import smoke check
/Users/jinle/.local/bin/uv run python -c "import fastapi, yaml, pydantic, aiohttp; print('imports: ok')"
imports: ok
- Scenario orchestration YAML parse check
/Users/jinle/.local/bin/uv run python -c "from pathlib import Path; import yaml; files=list(Path('apps/artagent/backend/registries/scenariostore').rglob('orchestration.yaml')); [yaml.safe_load(p.read_text(encoding='utf-8')) for p in files]; print(f'orchestration yamls: {len(files)} parsed')"
orchestration yamls: 3 parsed smoke validation target and run it from setup steps

## Validation
- ran ⚡ Running ci-fast validation
- Python bytecode compile check
  • apps/artagent/backend
  • src
  • tests/evaluation
  • utils
- Dependency import smoke check
/Users/jinle/.local/bin/uv run python -c "import fastapi, yaml, pydantic, aiohttp; print('imports: ok')"
imports: ok
- Scenario orchestration YAML parse check
/Users/jinle/.local/bin/uv run python -c "from pathlib import Path; import yaml; files=list(Path('apps/artagent/backend/registries/scenariostore').rglob('orchestration.yaml')); [yaml.safe_load(p.read_text(encoding='utf-8')) for p in files]; print(f'orchestration yamls: {len(files)} parsed')"
orchestration yamls: 3 parsed locally successfully
