### PR TITLE
fix(genesys): AudioConnector connection-probe + WS subprotocol negotiation

### DIFF
--- a/apps/artagent/backend/api/v1/endpoints/genesys.py
+++ b/apps/artagent/backend/api/v1/endpoints/genesys.py
@@ -56,7 +56,16 @@ async def genesys_audiohook_stream(websocket: WebSocket):
 
     handler = GenesysVoiceLiveHandler(websocket=websocket, session_id=session_id)
 
-    await websocket.accept(subprotocol="audiohook-v2")
+    # Genesys AudioHook does NOT negotiate a WebSocket subprotocol — its handshake
+    # offers no ``Sec-WebSocket-Protocol`` header. Per RFC 6455 a server must only
+    # select a subprotocol the client offered; forcing one (the original
+    # ``"audiohook-v2"``) makes strict clients like Genesys abort the handshake with
+    # a generic error and empty server logs. Mirror only a subprotocol the client
+    # actually offered, otherwise select none.
+    offered = websocket.headers.get("sec-websocket-protocol", "")
+    offered_protocols = [p.strip() for p in offered.split(",") if p.strip()]
+    selected_subprotocol = "audiohook" if "audiohook" in offered_protocols else None
+    await websocket.accept(subprotocol=selected_subprotocol)
 
     try:
         await handler.start()

--- a/apps/artagent/backend/voice/genesys/handler.py
+++ b/apps/artagent/backend/voice/genesys/handler.py
@@ -360,6 +360,20 @@ class GenesysVoiceLiveHandler:
             )
             return
 
+        # Connection probe: Genesys validates the integration with a synthetic
+        # session (null-UUID conversationId) on activate/save. Complete the
+        # open/opened handshake so the probe passes, but do NOT allocate VoiceLive
+        # or orchestrator resources for it (per AudioHook patterns-and-practices).
+        if self._protocol.is_connection_probe(msg):
+            logger.info(
+                "[Genesys] Connection probe detected — short-circuiting open "
+                "(no VoiceLive allocation) | session=%s",
+                self.session_id,
+            )
+            await self._enqueue_message(self._protocol.create_opened(media))
+            self._session_opened = True
+            return
+
         # Send opened response immediately
         await self._enqueue_message(self._protocol.create_opened(media))
         self._session_opened = True

--- a/apps/artagent/backend/voice/genesys/protocol.py
+++ b/apps/artagent/backend/voice/genesys/protocol.py
@@ -66,6 +66,14 @@ DISCONNECT_ERROR = "error"
 SUPPORTED_FORMAT = "PCMU"
 SUPPORTED_RATE = 8000
 
+# Connection-probe sentinel. When an AudioConnector integration is activated or
+# saved, Genesys runs a connectivity probe: it opens a synthetic AudioHook session
+# with ``conversationId`` and ``participant.id`` set to the null UUID. The server
+# must complete the open/opened and close/closed transactions for the probe to
+# pass, but should NOT allocate downstream session resources (VoiceLive, etc.).
+# https://developer.genesys.cloud/devapps/audiohook/patterns-and-practices#connection-probe
+NULL_UUID = "00000000-0000-0000-0000-000000000000"
+
 
 class GenesysProtocol:
     """Manages AudioHook v2 protocol state and message construction.
@@ -172,6 +180,17 @@ class GenesysProtocol:
         logger.warning("[GenesysProtocol] No supported media format found in open message")
         return None
 
+    def is_connection_probe(self, msg: dict[str, Any]) -> bool:
+        """Return True if an 'open' message is a Genesys connection probe.
+
+        Genesys validates an AudioConnector integration on activate/save by opening
+        a synthetic session whose ``conversationId`` is the null UUID. The server
+        should short-circuit the open transaction (respond ``opened`` then handle the
+        ``close``) without allocating VoiceLive/orchestrator resources for the probe.
+        """
+        params = msg.get("parameters", {})
+        return params.get("conversationId") == NULL_UUID
+
     # ─────────────────────────────────────────────────────────────────────────
     # Outbound message construction
     # ─────────────────────────────────────────────────────────────────────────
@@ -188,9 +207,18 @@ class GenesysProtocol:
             "parameters": parameters,
         }
 
-    def create_opened(self, media: dict[str, Any]) -> dict[str, Any]:
-        """Create 'opened' response confirming media selection."""
-        return self._create_server_message(SERVER_MSG_OPENED, {"media": [media]})
+    def create_opened(
+        self, media: dict[str, Any], *, start_paused: bool = False
+    ) -> dict[str, Any]:
+        """Create 'opened' response confirming media selection.
+
+        Includes ``startPaused`` to match the AudioHook v2 'opened' schema. Genesys's
+        strict client expects this field in the opened parameters; omitting it can
+        cause a "malformed server message" rejection during the connection probe.
+        """
+        return self._create_server_message(
+            SERVER_MSG_OPENED, {"startPaused": start_paused, "media": [media]}
+        )
 
     def create_pong(self) -> dict[str, Any]:
         """Create 'pong' keep-alive response."""

--- a/apps/artagent/backend/voice/genesys/protocol.py
+++ b/apps/artagent/backend/voice/genesys/protocol.py
@@ -212,9 +212,11 @@ class GenesysProtocol:
     ) -> dict[str, Any]:
         """Create 'opened' response confirming media selection.
 
-        Includes ``startPaused`` to match the AudioHook v2 'opened' schema. Genesys's
-        strict client expects this field in the opened parameters; omitting it can
-        cause a "malformed server message" rejection during the connection probe.
+        Includes ``startPaused`` to match the AudioHook v2 'opened' schema example.
+        The field is *optional* per the schema, so its absence is not by itself a
+        protocol error (verified empirically: a deployment omitting it still passes
+        the Genesys connection probe). Emitting it explicitly is simply the
+        conformant shape every Genesys 'opened' example uses.
         """
         return self._create_server_message(
             SERVER_MSG_OPENED, {"startPaused": start_paused, "media": [media]}

--- a/tests/voice/genesys/test_genesys_endpoint.py
+++ b/tests/voice/genesys/test_genesys_endpoint.py
@@ -1,0 +1,168 @@
+"""Endpoint-level tests for the Genesys AudioHook v2 WebSocket route.
+
+These exercise the *real* FastAPI WebSocket endpoint
+(``/api/v1/genesys/stream``) end-to-end via Starlette's ``TestClient`` — the
+WebSocket handshake, subprotocol negotiation, and the open→opened transaction —
+without requiring the private Azure backend. The only thing stubbed is the
+VoiceLive connection itself (``_connect_voicelive``), so we can assert that a
+Genesys *connection probe* never allocates VoiceLive resources while a real
+conversation does.
+
+This is the integration counterpart to ``test_genesys_protocol.py`` and directly
+validates the fix for the IBM AudioConnector activation failure.
+
+Reference: https://developer.genesys.cloud/devapps/audiohook/patterns-and-practices
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, PropertyMock, patch
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from apps.artagent.backend.api.v1.endpoints.genesys import router
+from apps.artagent.backend.voice.genesys.handler import GenesysVoiceLiveHandler
+from apps.artagent.backend.voice.genesys.protocol import NULL_UUID
+
+SESSION_ID = "62780b08-3a9d-43b0-9d74-4aa5745fa633"
+
+PROBE_MEDIA = [
+    {"type": "audio", "format": "PCMU", "channels": ["external", "internal"], "rate": 8000},
+    {"type": "audio", "format": "PCMU", "channels": ["external"], "rate": 8000},
+    {"type": "audio", "format": "PCMU", "channels": ["internal"], "rate": 8000},
+]
+
+REAL_MEDIA = [
+    {"type": "audio", "format": "PCMU", "channels": ["external"], "rate": 8000},
+]
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/genesys")
+    return app
+
+
+def _open_message(*, conversation_id: str, media: list[dict], seq: int = 1) -> dict:
+    return {
+        "version": "2",
+        "id": SESSION_ID,
+        "type": "open",
+        "seq": seq,
+        "serverseq": 0,
+        "position": "PT0S",
+        "parameters": {
+            "organizationId": "aec04f7c-8108-4e07-a9d6-67a8d5df7b3e",
+            "conversationId": conversation_id,
+            "participant": {"id": conversation_id, "ani": "", "aniName": "", "dnis": ""},
+            "media": media,
+        },
+    }
+
+
+def _close_message(seq: int = 2) -> dict:
+    return {
+        "version": "2",
+        "id": SESSION_ID,
+        "type": "close",
+        "seq": seq,
+        "serverseq": 1,
+        "position": "PT1S",
+        "parameters": {},
+    }
+
+
+@pytest.fixture()
+def client():
+    return TestClient(_build_app())
+
+
+# ── Connection probe (the IBM activation path) ───────────────────────────────
+
+
+def test_connection_probe_completes_without_allocating_voicelive(client):
+    """A null-UUID probe must get a conformant ``opened`` and never touch VoiceLive."""
+    with patch.object(
+        GenesysVoiceLiveHandler, "_connect_voicelive", new_callable=AsyncMock
+    ) as mock_connect, patch.object(
+        GenesysVoiceLiveHandler, "_websocket_open", new_callable=PropertyMock, return_value=True
+    ):
+        with client.websocket_connect(
+            "/api/v1/genesys/stream",
+            headers={"audiohook-session-id": SESSION_ID},
+        ) as ws:
+            ws.send_text(json.dumps(_open_message(conversation_id=NULL_UUID, media=PROBE_MEDIA)))
+            opened = json.loads(ws.receive_text())
+
+            assert opened["type"] == "opened"
+            assert opened["id"] == SESSION_ID
+            assert opened["parameters"]["startPaused"] is False
+            assert opened["parameters"]["media"][0]["format"] == "PCMU"
+
+            # The whole point of the fix: a probe must NOT spin up VoiceLive.
+            mock_connect.assert_not_awaited()
+
+            # Probe then closes; server must answer with closed.
+            ws.send_text(json.dumps(_close_message()))
+            closed = json.loads(ws.receive_text())
+            assert closed["type"] == "closed"
+
+
+def test_real_conversation_open_allocates_voicelive(client):
+    """A real (non-null) conversationId must still drive a VoiceLive connection."""
+    with patch.object(
+        GenesysVoiceLiveHandler, "_connect_voicelive", new_callable=AsyncMock
+    ) as mock_connect, patch.object(
+        GenesysVoiceLiveHandler, "_websocket_open", new_callable=PropertyMock, return_value=True
+    ):
+        with client.websocket_connect(
+            "/api/v1/genesys/stream",
+            headers={"audiohook-session-id": SESSION_ID},
+        ) as ws:
+            ws.send_text(
+                json.dumps(
+                    _open_message(
+                        conversation_id="11111111-2222-3333-4444-555555555555",
+                        media=REAL_MEDIA,
+                    )
+                )
+            )
+            opened = json.loads(ws.receive_text())
+            assert opened["type"] == "opened"
+
+        mock_connect.assert_awaited_once()
+
+
+# ── WebSocket subprotocol negotiation (RFC 6455 conformance) ─────────────────
+
+
+def test_no_subprotocol_selected_when_client_offers_none(client):
+    """Genesys offers no subprotocol; the server must not force one."""
+    with patch.object(
+        GenesysVoiceLiveHandler, "_websocket_open", new_callable=PropertyMock, return_value=True
+    ):
+        with client.websocket_connect(
+            "/api/v1/genesys/stream",
+            headers={"audiohook-session-id": SESSION_ID},
+        ) as ws:
+            assert getattr(ws, "accepted_subprotocol", None) is None
+
+
+def test_subprotocol_mirrored_only_when_offered(client):
+    """If a client offers ``audiohook`` the server may echo exactly that token."""
+    with patch.object(
+        GenesysVoiceLiveHandler, "_websocket_open", new_callable=PropertyMock, return_value=True
+    ):
+        with client.websocket_connect(
+            "/api/v1/genesys/stream",
+            headers={"audiohook-session-id": SESSION_ID},
+            subprotocols=["audiohook"],
+        ) as ws:
+            assert getattr(ws, "accepted_subprotocol", None) == "audiohook"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/voice/genesys/test_genesys_protocol.py
+++ b/tests/voice/genesys/test_genesys_protocol.py
@@ -1,0 +1,170 @@
+"""Unit tests for the Genesys AudioHook v2 protocol layer.
+
+These are the first automated tests for the Genesys connector. They guard the
+regressions found while debugging an IBM AudioConnector integration that failed
+Genesys's activation connection probe:
+
+* Connection-probe detection (null-UUID conversationId).
+* ``opened`` message conformance — must carry ``startPaused`` per the AudioHook v2
+  schema, otherwise Genesys can reject it as a malformed server message.
+* Media selection / open-transaction handling.
+* Sequence-number + session-id validation.
+
+Reference: https://developer.genesys.cloud/devapps/audiohook/patterns-and-practices
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from apps.artagent.backend.voice.genesys.protocol import (
+    NULL_UUID,
+    GenesysProtocol,
+)
+
+SESSION_ID = "62780b08-3a9d-43b0-9d74-4aa5745fa633"
+
+EXTERNAL_MEDIA = {
+    "type": "audio",
+    "format": "PCMU",
+    "channels": ["external"],
+    "rate": 8000,
+}
+
+
+def _open_message(
+    *,
+    conversation_id: str,
+    media: list[dict] | None = None,
+    seq: int = 1,
+) -> dict:
+    """Build an AudioHook 'open' message matching Genesys's wire format."""
+    if media is None:
+        media = [dict(EXTERNAL_MEDIA)]
+    return {
+        "version": "2",
+        "id": SESSION_ID,
+        "type": "open",
+        "seq": seq,
+        "serverseq": 0,
+        "position": "PT0S",
+        "parameters": {
+            "organizationId": "aec04f7c-8108-4e07-a9d6-67a8d5df7b3e",
+            "conversationId": conversation_id,
+            "participant": {"id": conversation_id, "ani": "", "aniName": "", "dnis": ""},
+            "media": media,
+        },
+    }
+
+
+# ── Connection-probe detection ──────────────────────────────────────────────
+
+
+def test_connection_probe_detected_for_null_uuid():
+    proto = GenesysProtocol(SESSION_ID)
+    probe = _open_message(
+        conversation_id=NULL_UUID,
+        media=[
+            {"type": "audio", "format": "PCMU", "channels": ["external", "internal"], "rate": 8000},
+            {"type": "audio", "format": "PCMU", "channels": ["external"], "rate": 8000},
+            {"type": "audio", "format": "PCMU", "channels": ["internal"], "rate": 8000},
+        ],
+    )
+    assert proto.is_connection_probe(probe) is True
+
+
+def test_real_conversation_is_not_a_probe():
+    proto = GenesysProtocol(SESSION_ID)
+    real = _open_message(conversation_id="11111111-2222-3333-4444-555555555555")
+    assert proto.is_connection_probe(real) is False
+
+
+def test_missing_conversation_id_is_not_a_probe():
+    proto = GenesysProtocol(SESSION_ID)
+    assert proto.is_connection_probe({"parameters": {}}) is False
+    assert proto.is_connection_probe({}) is False
+
+
+def test_probe_offering_full_media_list_still_selects_supported_format():
+    """The probe sends a *full* media list (not empty); process_open must match it."""
+    proto = GenesysProtocol(SESSION_ID)
+    probe = _open_message(
+        conversation_id=NULL_UUID,
+        media=[
+            {"type": "audio", "format": "PCMU", "channels": ["external", "internal"], "rate": 8000},
+            {"type": "audio", "format": "PCMU", "channels": ["external"], "rate": 8000},
+        ],
+    )
+    selected = proto.process_open(probe)
+    assert selected is not None
+    assert selected["format"] == "PCMU"
+    assert selected["rate"] == 8000
+
+
+# ── opened message conformance ──────────────────────────────────────────────
+
+
+def test_opened_includes_start_paused_false_by_default():
+    proto = GenesysProtocol(SESSION_ID)
+    opened = proto.create_opened(dict(EXTERNAL_MEDIA))
+    assert opened["type"] == "opened"
+    assert opened["version"] == "2"
+    assert opened["id"] == SESSION_ID  # server must echo the client's session id
+    assert opened["parameters"]["startPaused"] is False
+    assert opened["parameters"]["media"] == [EXTERNAL_MEDIA]
+
+
+def test_opened_can_start_paused():
+    proto = GenesysProtocol(SESSION_ID)
+    opened = proto.create_opened(dict(EXTERNAL_MEDIA), start_paused=True)
+    assert opened["parameters"]["startPaused"] is True
+
+
+# ── open-transaction media selection ────────────────────────────────────────
+
+
+def test_process_open_selects_pcmu_8khz():
+    proto = GenesysProtocol(SESSION_ID)
+    selected = proto.process_open(_open_message(conversation_id=NULL_UUID))
+    assert selected == EXTERNAL_MEDIA
+
+
+def test_process_open_rejects_unsupported_format():
+    proto = GenesysProtocol(SESSION_ID)
+    msg = _open_message(
+        conversation_id=NULL_UUID,
+        media=[{"type": "audio", "format": "L16", "channels": ["external"], "rate": 16000}],
+    )
+    assert proto.process_open(msg) is None
+
+
+def test_process_open_with_empty_media_returns_none():
+    proto = GenesysProtocol(SESSION_ID)
+    msg = _open_message(conversation_id=NULL_UUID, media=[])
+    assert proto.process_open(msg) is None
+
+
+# ── sequence + session-id validation ────────────────────────────────────────
+
+
+def test_validate_message_rejects_session_id_mismatch():
+    proto = GenesysProtocol(SESSION_ID)
+    foreign = _open_message(conversation_id=NULL_UUID)
+    foreign["id"] = "deadbeef-0000-0000-0000-000000000000"
+    assert proto.validate_message(json.dumps(foreign)) is None
+
+
+def test_validate_message_accepts_matching_id_and_tracks_seq():
+    proto = GenesysProtocol(SESSION_ID)
+    parsed = proto.validate_message(json.dumps(_open_message(conversation_id=NULL_UUID, seq=1)))
+    assert parsed is not None
+    # opened should mirror the just-received client seq
+    opened = proto.create_opened(dict(EXTERNAL_MEDIA))
+    assert opened["clientseq"] == 1
+    assert opened["seq"] == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/voice/genesys/test_genesys_protocol.py
+++ b/tests/voice/genesys/test_genesys_protocol.py
@@ -5,8 +5,8 @@ regressions found while debugging an IBM AudioConnector integration that failed
 Genesys's activation connection probe:
 
 * Connection-probe detection (null-UUID conversationId).
-* ``opened`` message conformance — must carry ``startPaused`` per the AudioHook v2
-  schema, otherwise Genesys can reject it as a malformed server message.
+* ``opened`` message conformance — should carry ``startPaused`` to match the
+  AudioHook v2 'opened' schema example (the field is optional per the schema).
 * Media selection / open-transaction handling.
 * Sequence-number + session-id validation.
 

--- a/tools/genesys_simulator/README.md
+++ b/tools/genesys_simulator/README.md
@@ -41,6 +41,41 @@ python genesys_client_simulator.py wss://<your-app>.azurecontainerapps.io/api/v1
 
 The URL can also be set via `SIMULATOR_SERVER_URL` in your `.env` file.
 
+## Connection Probe (diagnostic)
+
+`probe_connection.py` is a headless, no-microphone diagnostic that reproduces the
+**exact handshake Genesys Cloud performs when you activate an Audio Connector
+integration** (or toggle it Inactive → Active). Use it to verify any ART
+deployment's `/api/v1/genesys/stream` endpoint without a Genesys account or audio
+hardware — handy in CI or when triaging an activation failure.
+
+```bash
+# Local backend
+python probe_connection.py ws://localhost:8081/api/v1/genesys/stream
+
+# Deployed backend
+python probe_connection.py wss://<your-app>.azurecontainerapps.io/api/v1/genesys/stream
+```
+
+The probe sends an AudioHook `open` whose `conversationId`/`participant.id` are the
+null UUID (`00000000-0000-0000-0000-000000000000`) — the marker Genesys uses for
+its activation probe — then closes. It checks and prints PASS/FAIL for:
+
+| Check | What it verifies |
+|-------|------------------|
+| Subprotocol negotiation | The server does **not** select a `Sec-WebSocket-Protocol` the client never offered. Genesys offers none; selecting one (e.g. `audiohook-v2`) makes a strict client abort the handshake — surfacing as a generic "problem communicating with the AudioConnector Bot" error with empty server logs. |
+| `opened` within 5s | The server answers `open` with `opened` inside the Genesys activation window. |
+| No audio during probe | The activation probe is not a real call, so the server should stream no audio. |
+| Clean close | The server returns `closed`/`disconnect` after the client's `close`. |
+
+Exit code is `0` when all checks pass, `1` otherwise. By default the probe offers
+no subprotocol (mirroring Genesys exactly); pass `--offer-subprotocol audiohook`
+only to exercise negotiation behavior.
+
+> Note: "AudioHook v2" refers to the `version` field inside the JSON `open`
+> message — it is **not** a WebSocket subprotocol. Genesys negotiates no
+> subprotocol on the wire.
+
 ## Configuration
 
 All settings are optional and configured via `.env` (see `.env.sample`):

--- a/tools/genesys_simulator/probe_connection.py
+++ b/tools/genesys_simulator/probe_connection.py
@@ -1,0 +1,214 @@
+"""Genesys AudioConnector connection-probe diagnostic.
+
+Reproduces the *exact* handshake Genesys Cloud performs when you activate (or
+toggle Inactive -> Active) an Audio Connector integration, and reports whether
+the target server handles it correctly. Use it to verify any ART deployment's
+``/api/v1/genesys/stream`` endpoint without a Genesys account.
+
+The Genesys activation probe is a regular AudioHook ``open`` whose
+``conversationId`` and ``participant.id`` are the null UUID
+(``00000000-0000-0000-0000-000000000000``). A conformant server must:
+
+  1. Complete the WebSocket handshake. Genesys offers **no**
+     ``Sec-WebSocket-Protocol`` header, so the server must NOT select a
+     subprotocol the client did not offer (doing so makes a strict client
+     abort the handshake -- the classic "problem communicating with the
+     AudioConnector Bot" failure with empty server logs).
+  2. Answer ``open`` with ``opened`` within ~5s.
+  3. Send NO audio for the probe (it is not a real call).
+  4. Close cleanly when the client sends ``close``.
+
+Exit code is 0 when all checks pass, 1 otherwise -- so it can be wired into CI
+or a smoke test.
+
+Examples::
+
+    python probe_connection.py ws://localhost:8081/api/v1/genesys/stream
+    python probe_connection.py wss://<your-app>.azurecontainerapps.io/api/v1/genesys/stream
+    python probe_connection.py --offer-subprotocol audiohook wss://<your-app>/api/v1/genesys/stream
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+
+import websocket  # websocket-client
+
+NULL_UUID = "00000000-0000-0000-0000-000000000000"
+DEFAULT_URL = os.environ.get(
+    "GENESYS_PROBE_URL", "ws://localhost:8081/api/v1/genesys/stream"
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="probe_connection.py",
+        description="Replay the Genesys AudioConnector activation probe against an ART endpoint.",
+    )
+    p.add_argument(
+        "url",
+        nargs="?",
+        default=DEFAULT_URL,
+        help=f"WebSocket URL of the Genesys stream endpoint (default: {DEFAULT_URL})",
+    )
+    p.add_argument(
+        "--offer-subprotocol",
+        metavar="NAME",
+        default=None,
+        help=(
+            "Offer this WebSocket subprotocol on the handshake. Genesys offers "
+            "NONE, so leave this unset to mirror Genesys exactly; set it only to "
+            "test negotiation behavior."
+        ),
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Per-message receive timeout in seconds (default: 10).",
+    )
+    return p.parse_args(argv)
+
+
+def run_probe(url: str, offer_subprotocol: str | None, timeout: float) -> bool:
+    session_id = str(uuid.uuid4())
+    org_id = str(uuid.uuid4())
+
+    print(f"Target: {url}")
+    print(
+        f"Mode:   connection probe (null-UUID) | "
+        f"offer_subprotocol={offer_subprotocol or 'none (Genesys-exact)'}"
+    )
+    print(f"Session: {session_id}\n")
+
+    kwargs: dict = dict(
+        header={
+            "audiohook-session-id": session_id,
+            "audiohook-organization-id": org_id,
+            "audiohook-correlation-id": str(uuid.uuid4()),
+        },
+        timeout=timeout,
+    )
+    if offer_subprotocol:
+        kwargs["subprotocols"] = [offer_subprotocol]
+
+    try:
+        ws = websocket.create_connection(url, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - surface any handshake failure
+        print(f"  HANDSHAKE FAILED: {type(exc).__name__}: {exc}")
+        return False
+
+    negotiated = ws.subprotocol
+    print(f"  [ 0.00s] handshake OK | negotiated subprotocol={negotiated!r}")
+
+    # A server must not select a subprotocol the client did not offer.
+    subprotocol_ok = True
+    if not offer_subprotocol and negotiated:
+        subprotocol_ok = False
+        print(
+            f"        WARNING: server selected subprotocol {negotiated!r} "
+            f"but the client offered none (RFC 6455 violation)."
+        )
+
+    open_msg = {
+        "version": "2",
+        "id": session_id,
+        "type": "open",
+        "seq": 1,
+        "position": "PT0S",
+        "parameters": {
+            "organizationId": org_id,
+            "conversationId": NULL_UUID,
+            "participant": {"id": NULL_UUID, "ani": "", "aniName": "", "dnis": ""},
+            "media": [
+                {"type": "audio", "format": "PCMU", "channels": ["external", "internal"], "rate": 8000},
+                {"type": "audio", "format": "PCMU", "channels": ["external"], "rate": 8000},
+                {"type": "audio", "format": "PCMU", "channels": ["internal"], "rate": 8000},
+            ],
+            "language": None,
+            "customConfig": {},
+        },
+        "serverseq": 0,
+    }
+
+    t0 = time.monotonic()
+    ws.send(json.dumps(open_msg))
+    print("  [ 0.00s] -> open (probe)")
+
+    opened_at: float | None = None
+    binary_frames = 0
+    closed_cleanly = False
+    ws.settimeout(timeout)
+
+    for _ in range(20):
+        try:
+            msg = ws.recv()
+        except websocket.WebSocketTimeoutException:
+            print("        (timeout waiting for next message)")
+            break
+        except Exception as exc:  # noqa: BLE001
+            print(f"  <- ERROR: {type(exc).__name__}: {exc}")
+            break
+
+        dt = time.monotonic() - t0
+        if isinstance(msg, (bytes, bytearray)):
+            binary_frames += 1
+            print(f"  [{dt:5.2f}s] <- BINARY frame, {len(msg)} bytes (probe should receive NO audio)")
+            continue
+
+        parsed = json.loads(msg)
+        mtype = parsed.get("type")
+        params = parsed.get("parameters", {})
+        print(f"  [{dt:5.2f}s] <- {mtype}")
+
+        if mtype == "opened":
+            opened_at = dt
+            print(f"        startPaused present: {'startPaused' in params}")
+            close_msg = {
+                "version": "2", "id": session_id, "type": "close", "seq": 2,
+                "position": "PT0S", "parameters": {"reason": "end"}, "serverseq": 1,
+            }
+            ws.send(json.dumps(close_msg))
+            print(f"  [{dt:5.2f}s] -> close (reason=end)")
+        elif mtype in ("closed", "disconnect"):
+            closed_cleanly = True
+            break
+        elif mtype == "error":
+            print(f"        server error: {json.dumps(params)[:300]}")
+            break
+
+    try:
+        ws.close()
+    except Exception:  # noqa: BLE001
+        pass
+
+    opened_ok = opened_at is not None and opened_at <= 5.0
+    no_audio_ok = binary_frames == 0
+
+    print("\n=== PROBE RESULT ===")
+    print(f"  [{'PASS' if subprotocol_ok else 'FAIL'}] subprotocol negotiation")
+    print(
+        f"  [{'PASS' if opened_ok else 'FAIL'}] opened within 5s "
+        f"({'%.2fs' % opened_at if opened_at is not None else 'not received'})"
+    )
+    print(f"  [{'PASS' if no_audio_ok else 'FAIL'}] no audio during probe ({binary_frames} binary frames)")
+    print(f"  [{'PASS' if closed_cleanly else 'WARN'}] clean close (closed/disconnect received)")
+
+    passed = subprotocol_ok and opened_ok and no_audio_ok
+    print(f"\n{'PROBE PASSED' if passed else 'PROBE FAILED'} - "
+          f"server-side protocol path is {'healthy' if passed else 'NOT healthy'} as deployed.")
+    return passed
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    ok = run_probe(args.url, args.offer_subprotocol, args.timeout)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Builds on #159 (Genesys Cloud AudioConnector integration). Corrects the WebSocket subprotocol negotiation that prevents the Genesys activation handshake from completing, and adds the connector's first automated tests.

## Root cause
The endpoint accepted the WebSocket with `subprotocol="audiohook-v2"`. However, `"v2"` is the AudioHook **message version** (the `version` field inside the JSON `open` message) — it is **not** a WebSocket subprotocol, and Genesys offers no `Sec-WebSocket-Protocol` header on the wire. Per RFC 6455 §4.2.2, a server may only select a subprotocol the client actually offered; selecting an unoffered one causes a strict client to abort the handshake. This surfaces as a generic "problem communicating with the AudioConnector Bot" error with empty backend logs and no call connecting.

## Changes
- **Subprotocol negotiation** (`api/v1/endpoints/genesys.py`): mirror only a subprotocol the client actually offered; otherwise select none.
- **Connection-probe short-circuit** (`voice/genesys/protocol.py`, `handler.py`): detect the null-UUID activation probe and answer `opened` without spinning up a VoiceLive session.
- **`startPaused`** (`protocol.py`): emit in the `opened` message for AudioHook v2 conformance.
- **Tests** (`tests/voice/genesys/`): first automated coverage for the connector — 15 tests (11 protocol unit + 4 endpoint WebSocket), all passing.

## Validation
- External AudioHook client replaying the exact Genesys activation probe (null-UUID conversation → `close`) against a live deployment completes `open → opened → close` cleanly.
- 15/15 tests pass; `py_compile` clean; conflict-free against current `main`.
