### PR TITLE
fix(ui): GPU-composite voice orchestration diagram to fix jank

### DIFF
--- a/apps/artagent/frontend/src/components/OrchestrationDiagram.jsx
+++ b/apps/artagent/frontend/src/components/OrchestrationDiagram.jsx
@@ -194,10 +194,15 @@ const styles = {
 };
 
 // Injected once — keyframes + hover effects that inline styles can't express.
+// Perf note: the flow dot animates `transform`/`opacity` only (GPU-composited,
+// no per-frame layout/paint). We deliberately avoid animating `left` or
+// `background-position` here because a single open modal renders ~6–10
+// connectors and those properties would force main-thread reflows/repaints on
+// every frame for every connector.
 const KEYFRAMES = `
-@keyframes od-flow { 0% { background-position: 0% 0; } 100% { background-position: -200% 0; } }
-@keyframes od-dot { 0% { left: 6%; opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { left: 94%; opacity: 0; } }
+@keyframes od-dot { 0% { transform: translate(0, -50%); opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { transform: translate(18px, -50%); opacity: 0; } }
 @keyframes od-fade { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+.od-dot { animation: od-dot 1.6s linear infinite; will-change: transform, opacity; }
 .od-stage { transition: transform .2s cubic-bezier(.4,0,.2,1), box-shadow .2s ease, border-color .2s ease, background .2s ease; }
 .od-stage:hover { transform: translateY(-3px); box-shadow: 0 12px 24px rgba(15,23,42,.13) !important; }
 .od-card { transition: transform .2s cubic-bezier(.4,0,.2,1), box-shadow .2s ease, border-color .2s ease; }
@@ -205,9 +210,17 @@ const KEYFRAMES = `
 .od-close { transition: background .15s ease, color .15s ease, border-color .15s ease; }
 .od-close:hover { background: #f1f5f9 !important; color: #0f172a !important; border-color: #cbd5e1 !important; }
 .od-fade { animation: od-fade .4s cubic-bezier(.4,0,.2,1); }
+@media (prefers-reduced-motion: reduce) {
+  .od-dot { animation: none; opacity: 1; }
+  .od-fade { animation: none; }
+  .od-stage, .od-card, .od-close { transition: none !important; }
+}
 `;
 
-// Animated flowing connector between pipeline nodes.
+// Flowing connector between pipeline nodes. A static gradient line plus a
+// single GPU-composited dot conveys the "flow" without the previous
+// double infinite animation (background-position + left) that pinned the
+// main thread.
 function FlowConnector({ color }) {
   return (
     <div
@@ -220,22 +233,21 @@ function FlowConnector({ color }) {
         alignSelf: 'center',
         borderRadius: '999px',
         background: `linear-gradient(90deg, ${color.main}22 0%, ${color.main} 50%, ${color.main}22 100%)`,
-        backgroundSize: '200% 100%',
-        animation: 'od-flow 1.6s linear infinite',
         overflow: 'visible',
       }}
     >
       <span
+        className="od-dot"
         style={{
           position: 'absolute',
           top: '50%',
+          left: 0,
           width: '6px',
           height: '6px',
           borderRadius: '50%',
           background: color.main,
           boxShadow: `0 0 8px ${color.main}`,
           transform: 'translateY(-50%)',
-          animation: 'od-dot 1.6s linear infinite',
         }}
       />
     </div>

--- a/docs/js/orchestration-diagram.js
+++ b/docs/js/orchestration-diagram.js
@@ -56,25 +56,33 @@
     },
   };
 
+  // Perf note: the flow dot animates `transform`/`opacity` only (GPU-composited).
+  // We avoid animating `left`/`background-position` because the widget renders
+  // ~6–10 connectors and those would force per-frame reflows/repaints.
   const KEYFRAMES = `
-@keyframes odx-flow { 0% { background-position: 0% 0; } 100% { background-position: -200% 0; } }
-@keyframes odx-dot { 0% { left: 6%; opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { left: 94%; opacity: 0; } }
+@keyframes odx-dot { 0% { transform: translate(0, -50%); opacity: 0; } 20% { opacity: 1; } 80% { opacity: 1; } 100% { transform: translate(18px, -50%); opacity: 0; } }
 @keyframes odx-fade { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 #orchestration-interactive { all: initial; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; display: block; }
 #orchestration-interactive * { box-sizing: border-box; }
+.odx-dot { animation: odx-dot 1.6s linear infinite; will-change: transform, opacity; }
 .odx-stage { transition: transform .2s cubic-bezier(.4,0,.2,1), box-shadow .2s ease, border-color .2s ease, background .2s ease; }
 .odx-stage:hover { transform: translateY(-3px); box-shadow: 0 12px 24px rgba(15,23,42,.13) !important; }
 .odx-card { transition: transform .2s cubic-bezier(.4,0,.2,1), box-shadow .2s ease, border-color .2s ease; }
 .odx-card:hover { transform: translateY(-2px); box-shadow: 0 10px 22px rgba(15,23,42,.10); }
 .odx-fade { animation: odx-fade .4s cubic-bezier(.4,0,.2,1); }
 .odx-btn { cursor: pointer; font-family: inherit; }
+@media (prefers-reduced-motion: reduce) {
+  .odx-dot { animation: none; opacity: 1; }
+  .odx-fade { animation: none; }
+  .odx-stage, .odx-card { transition: none !important; }
+}
 `;
 
   const ENDPOINT = 'display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;flex:0 0 auto;min-width:58px;padding:11px 8px;border-radius:14px;background:linear-gradient(135deg,#334155 0%,#0f172a 100%);color:#e2e8f0;font-size:10px;font-weight:600;text-align:center;box-shadow:0 4px 10px rgba(15,23,42,0.18)';
 
   function connector(color) {
-    return `<div aria-hidden="true" style="position:relative;flex:0 0 24px;min-width:24px;height:3px;align-self:center;border-radius:999px;background:linear-gradient(90deg,${color.main}22 0%,${color.main} 50%,${color.main}22 100%);background-size:200% 100%;animation:odx-flow 1.6s linear infinite">`
-      + `<span style="position:absolute;top:50%;width:6px;height:6px;border-radius:50%;background:${color.main};box-shadow:0 0 8px ${color.main};transform:translateY(-50%);animation:odx-dot 1.6s linear infinite"></span></div>`;
+    return `<div aria-hidden="true" style="position:relative;flex:0 0 24px;min-width:24px;height:3px;align-self:center;border-radius:999px;background:linear-gradient(90deg,${color.main}22 0%,${color.main} 50%,${color.main}22 100%)">`
+      + `<span class="odx-dot" style="position:absolute;top:50%;left:0;width:6px;height:6px;border-radius:50%;background:${color.main};box-shadow:0 0 8px ${color.main};transform:translateY(-50%)"></span></div>`;
   }
 
   function stageCard(stage, color, active) {


### PR DESCRIPTION
## Hotfix: voice orchestration diagram performance

The **"How voice orchestration works"** modal was heavy/janky while open.

### Root cause
The modal renders 6–10 `FlowConnector`s, each running **two infinite, non-composited CSS animations**:
- `od-flow` animating `background-position` → per-frame **paint** on every connector line
- `od-dot` animating `left` → per-frame **layout reflow** on every dot

That's 12–20 simultaneous main-thread reflow/repaint animations the whole time the dialog is open.

### Fix
- Animate the flow dot via `transform`/`opacity` only (GPU-composited) instead of `left`
- Drop the redundant `background-position` "flow" animation; keep a static gradient line + the traveling dot
- Add `will-change` and a `prefers-reduced-motion` fallback

Visual appearance is essentially unchanged. Applied to both the React component (`OrchestrationDiagram.jsx`) and the mirrored docs widget (`docs/js/orchestration-diagram.js`).