### PR TITLE
Fix redundant VoiceLive speech-start response cancellation

### DIFF
--- a/apps/artagent/backend/voice/voicelive/orchestrator.py
+++ b/apps/artagent/backend/voice/voicelive/orchestrator.py
@@ -1255,7 +1255,7 @@ class LiveOrchestrator:
 
     async def _handle_speech_started(self) -> None:
         """Handle user speech started (barge-in)."""
-        logger.debug("User speech started → cancel current response")
+        logger.debug("User speech started → stop current playback")
         
         # Sync state to MemoManager in background - don't block barge-in response
         # This ensures any partial response context is preserved
@@ -1263,16 +1263,6 @@ class LiveOrchestrator:
         
         if self.audio:
             await self.audio.stop_playback()
-        # Only cancel when a response is actually in flight. Cancelling with no
-        # active response makes VoiceLive emit a `response_cancel_not_active`
-        # server error, which the handler treats as a hard error (StopAudio +
-        # UI error) and breaks the next turn. This race widens when VAD fires
-        # speech_started right after a turn completes (low silence_duration).
-        if self._active_response_id:
-            try:
-                await self.conn.response.cancel()
-            except Exception:
-                logger.debug("response.cancel() failed during barge-in", exc_info=True)
         if self.messenger and self._active_response_id:
             try:
                 await self.messenger.send_assistant_cancelled(
@@ -2576,4 +2566,3 @@ __all__ = [
     "get_voicelive_orchestrator",
     "get_orchestrator_registry_size",
 ]
-

--- a/docs/legacy/architecture/orchestration/orchestrators.md
+++ b/docs/legacy/architecture/orchestration/orchestrators.md
@@ -161,13 +161,14 @@ async def _switch_to(self, agent_name: str, system_vars: dict):
 
 ### Barge-In Handling
 
-Automatic via `SPEECH_STARTED` events:
+With the default `interrupt_response=true` VAD configuration, VoiceLive cancels
+the response automatically. The `SPEECH_STARTED` handler only needs to stop local
+playback, not send another `response.cancel`:
 
 ```python
 async def _handle_speech_started(self):
     if self.audio:
         await self.audio.stop_playback()
-    await self.conn.response.cancel()
 ```
 
 ---

--- a/docs/legacy/architecture/orchestration/voicelive.md
+++ b/docs/legacy/architecture/orchestration/voicelive.md
@@ -258,19 +258,20 @@ async def _execute_tool_call(
 
 ## Barge-In Handling
 
-When the user starts speaking, the orchestrator cancels the current response:
+With the default `interrupt_response=true` VAD configuration, VoiceLive cancels the
+current response when the user starts speaking. The orchestrator stops local
+playback and notifies the UI without sending a redundant `response.cancel`.
+Explicit cancellation is still needed for application-driven handoffs and
+transfers, or custom configurations that disable automatic interruption.
 
 ```python
 async def _handle_speech_started(self) -> None:
     """Handle user speech started (barge-in)."""
-    logger.debug("User speech started → cancel current response")
+    logger.debug("User speech started → stop current playback")
     
     # Stop audio playback
     if self.audio:
         await self.audio.stop_playback()
-    
-    # Cancel model response
-    await self.conn.response.cancel()
     
     # Notify UI
     if self.messenger and self._active_response_id:

--- a/samples/voice_live_sdk/helloworld.py
+++ b/samples/voice_live_sdk/helloworld.py
@@ -292,8 +292,6 @@ class BasicVoiceAssistant:
         self.connection: Optional["VoiceLiveConnection"] = None
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
-        self._active_response = False
-        self._response_api_done = False
 
     async def start(self):
         """Start the voice assistant session."""
@@ -400,25 +398,12 @@ class BasicVoiceAssistant:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -430,16 +415,11 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/samples/voice_live_sdk/voicelive_multiagent/test.py
+++ b/samples/voice_live_sdk/voicelive_multiagent/test.py
@@ -281,8 +281,6 @@ class BasicVoiceAssistant:
         self.connection: Optional["VoiceLiveConnection"] = None
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
-        self._active_response = False
-        self._response_api_done = False
         self._current_voice_name = voice
         self._alternate_voices = ("en-US-AndrewNeural", "en-US-AvaNeural")
         self._alternate_index = 0
@@ -378,16 +376,6 @@ class BasicVoiceAssistant:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
         elif event.type == ServerEventType.SESSION_UPDATED:
             logger.info("Session updated: %s", event.session.id)
             logger.info("Session details: %s", event)
@@ -402,8 +390,6 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -415,8 +401,6 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
             try:
                 await self._rotate_voice_for_next_response()
             except Exception:
@@ -424,11 +408,8 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/tests/test_voicelive_barge_in.py
+++ b/tests/test_voicelive_barge_in.py
@@ -24,6 +24,7 @@ import pytest
 from fastapi.websockets import WebSocketState
 
 from apps.artagent.backend.voice.voicelive.handler import VoiceLiveSDKHandler
+from apps.artagent.backend.voice.voicelive.orchestrator import LiveOrchestrator
 from azure.ai.voicelive.models import ServerEventType
 
 
@@ -147,3 +148,38 @@ async def test_response_done_prunes_cancelled_set():
     )
 
     assert "resp-1" not in handler._cancelled_response_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response_id", [None, "resp-1"])
+@pytest.mark.parametrize("with_audio", [False, True])
+async def test_orchestrator_stops_playback_without_cancelling_response(response_id, with_audio):
+    conn = SimpleNamespace(response=SimpleNamespace(cancel=AsyncMock()))
+    audio = SimpleNamespace(stop_playback=AsyncMock()) if with_audio else None
+    messenger = SimpleNamespace(send_assistant_cancelled=AsyncMock())
+    orchestrator = LiveOrchestrator(
+        conn=conn,
+        agents={"Concierge": Mock()},
+        audio_processor=audio,
+        messenger=messenger,
+    )
+    orchestrator._active_response_id = response_id
+    orchestrator._schedule_background_sync = Mock()
+
+    await orchestrator.handle_event(
+        SimpleNamespace(type=ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED)
+    )
+
+    orchestrator._schedule_background_sync.assert_called_once_with()
+    conn.response.cancel.assert_not_called()
+    if audio:
+        audio.stop_playback.assert_awaited_once_with()
+    if response_id:
+        messenger.send_assistant_cancelled.assert_awaited_once_with(
+            response_id=response_id,
+            sender="Concierge",
+            reason="user_barge_in",
+        )
+    else:
+        messenger.send_assistant_cancelled.assert_not_called()
+    assert orchestrator._active_response_id is None

--- a/tests/test_voicelive_samples.py
+++ b/tests/test_voicelive_samples.py
@@ -1,0 +1,87 @@
+"""Regression coverage for service-managed interruption in the VoiceLive samples."""
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from azure.ai.voicelive.models import ServerEventType
+
+
+@pytest.fixture(params=["helloworld.py", "voicelive_multiagent/test.py"])
+def sample_assistant(request, tmp_path, monkeypatch):
+    sample_path = Path(__file__).resolve().parents[1] / "samples" / "voice_live_sdk" / request.param
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch("os.chdir"),
+        patch("dotenv.load_dotenv"),
+        patch("logging.basicConfig"),
+        patch("logging.getLogger"),
+        patch("logging.FileHandler"),
+    ):
+        sample = runpy.run_path(str(sample_path))
+
+    assistant = sample["BasicVoiceAssistant"](
+        endpoint="https://example.services.ai.azure.com",
+        credential=Mock(),
+        model="gpt-realtime",
+        voice="en-US-AvaNeural",
+        instructions="You are a helpful assistant.",
+    )
+    assistant.connection = SimpleNamespace(
+        response=SimpleNamespace(cancel=AsyncMock()),
+        session=SimpleNamespace(update=AsyncMock()),
+    )
+    assistant.audio_processor = Mock()
+    return assistant
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "preceding_events",
+    [
+        [],
+        [ServerEventType.RESPONSE_CREATED],
+        [ServerEventType.RESPONSE_CREATED, ServerEventType.RESPONSE_DONE],
+    ],
+    ids=["idle", "responding", "completed"],
+)
+async def test_speech_started_clears_playback_without_cancelling(sample_assistant, preceding_events):
+    for event_type in preceding_events:
+        await sample_assistant._handle_event(SimpleNamespace(type=event_type))
+
+    await sample_assistant._handle_event(
+        SimpleNamespace(type=ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED)
+    )
+
+    sample_assistant.audio_processor.skip_pending_audio.assert_called_once_with()
+    sample_assistant.connection.response.cancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_keeps_service_managed_interruption(sample_assistant):
+    await sample_assistant._setup_session()
+
+    session = sample_assistant.connection.session.update.call_args.kwargs["session"].as_dict()
+    assert session["turn_detection"]["type"] == "server_vad"
+    assert session["turn_detection"].get("interrupt_response", True) is True
+
+
+@pytest.mark.asyncio
+async def test_audio_is_still_queued_for_playback(sample_assistant):
+    await sample_assistant._handle_event(
+        SimpleNamespace(type=ServerEventType.RESPONSE_AUDIO_DELTA, delta=b"\x00\x00")
+    )
+
+    sample_assistant.audio_processor.queue_audio.assert_called_once_with(b"\x00\x00")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message", ["Unexpected error", "Cancellation failed: no active response"])
+async def test_server_errors_are_reported(sample_assistant, capsys, message):
+    await sample_assistant._handle_event(
+        SimpleNamespace(type=ServerEventType.ERROR, error=SimpleNamespace(message=message))
+    )
+
+    assert f"Error: {message}" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Remove three redundant speech-start `response.cancel()` calls: the two VoiceLive SDK samples and `LiveOrchestrator._handle_speech_started`. These configurations use VAD's default service-managed interruption.
- Preserve local playback stopping, audio queue handling, background state sync, and UI cancellation notifications. Remove only the samples' now-unused cancellation flags and cancellation-specific error suppression.
- Update the two legacy orchestration examples and add focused regression coverage.

The five application-driven cancellation sites for session readiness, explicit greetings, handoffs, and call transfers remain unchanged, as does their shared cancel-race error handling. No `interrupt_response=false` configurations were found. Azure OpenAI Realtime code, SDK APIs, authentication, and dependencies are unchanged.

## Validation

- Dependency-free execution of the actual baseline and updated handlers reproduced the redundant cancellation and passed all 10 updated speech-start scenarios, including idle/completed responses, with/without local audio, playback stopping, audio queuing, state sync, UI notification, and sample error reporting.
- Python compilation passed for all five changed Python files; `git diff --check` passed.
- **Pytest could not run:** this fresh checkout has no pytest installation. Restoring existing dependencies with `uv sync --frozen --extra dev --python 3.11` failed because TLS connections to `files.pythonhosted.org` returned `Socket is not connected`; the required packages were also unavailable offline. TLS verification was not disabled, and dependency manifests/lockfiles were not changed.

Targeted command to run in an installed development environment:

```sh
python -m pytest tests/test_voicelive_samples.py tests/test_voicelive_barge_in.py tests/test_voicelive_memory.py -q
```